### PR TITLE
Require runner's role to be "master" or "agent"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Flags:
       --list                  List runner
 
 Global Flags:
-      --config string   config file (default is $HOME/.dcos-check-runner.yaml)
+      --config string   config file (default is /opt/mesosphere/etc/dcos-check-runner.yaml)
       --role string     Set node role
       --verbose         Use verbose debug output.
       --version         Print dcos-check-runner version

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -54,12 +54,7 @@ var checkCmd = &cobra.Command{
 			selectiveChecks = args[1:]
 		}
 
-		var (
-			err error
-			r   *runner.Runner
-		)
-
-		r, err = runner.NewRunner(defaultConfig.FlagRole)
+		r, err := runner.NewRunner(defaultConfig.FlagRole)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -54,7 +54,16 @@ var checkCmd = &cobra.Command{
 			selectiveChecks = args[1:]
 		}
 
-		r := runner.NewRunner(defaultConfig.FlagRole)
+		var (
+			err error
+			r   *runner.Runner
+		)
+
+		r, err = runner.NewRunner(defaultConfig.FlagRole)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		if err := r.LoadFromFile(checksCfgFile); err != nil {
 			logrus.Fatal(err)
 		}
@@ -64,13 +73,10 @@ var checkCmd = &cobra.Command{
 			os.Setenv(k, v)
 		}
 
-		var (
-			rs  *runner.CombinedResponse
-			err error
-		)
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		var rs *runner.CombinedResponse
 
 		switch args[0] {
 		case checkTypeCluster:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	RootCmd.PersistentFlags().BoolVar(&version, "version", false, "Print dcos-check-runner version")
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.dcos-check-runner.yaml)")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is /opt/mesosphere/etc/dcos-check-runner.yaml)")
 	RootCmd.PersistentFlags().BoolVar(&defaultConfig.FlagVerbose, "verbose", defaultConfig.FlagVerbose,
 		"Use verbose debug output.")
 	RootCmd.PersistentFlags().StringVar(&defaultConfig.FlagRole, "role", defaultConfig.FlagRole,
@@ -69,7 +69,7 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	viper.SetConfigName("dcos-check-config") // name of config file (without extension)
+	viper.SetConfigName("dcos-check-runner") // name of config file (without extension)
 	viper.AddConfigPath("/opt/mesosphere/etc/")
 	viper.AutomaticEnv()
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -17,18 +17,14 @@ const (
 	statusUnknown = 3
 )
 
-// NewRunner returns an initialized instance of *Runner.
-func NewRunner(role string) *Runner {
-	// according to design doc, runner config must treat roles `agent` and `agent_public`
-	// as a single `agent` role. If a user create a config and sets role `agent`, we expect to run this
-	// check on both agent and agent_public nodes.
-	// https://jira.mesosphere.com/browse/DCOS_OSS-1242
-	if role == dcos.RoleAgentPublic {
-		role = dcos.RoleAgent
+// NewRunner returns an initialized instance of *Runner. It returns an error if the role is not master or agent.
+func NewRunner(role string) (*Runner, error) {
+	switch role {
+	case dcos.RoleMaster, dcos.RoleAgent:
+	default:
+		return nil, errors.New(fmt.Sprintf("Runner role must be one of \"%s\" or \"%s\". Got \"%s\"", dcos.RoleMaster, dcos.RoleAgent, role))
 	}
-	return &Runner{
-		role: role,
-	}
+	return &Runner{role: role}, nil
 }
 
 // Response provides a command Response.

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -26,24 +26,39 @@ func TestConfigLoadConfig(t *testing.T) {
 }
 
 func TestNewRunner(t *testing.T) {
-	r := NewRunner("master")
-	if r.role != "master" {
-		t.Fatalf("expecting role master. Got %s", r.role)
+	// Assert that the only allowed roles are master and agent.
+	var (
+		r   *Runner
+		err error
+	)
+
+	// NewRunner() should succeed with these roles.
+	for _, role := range []string{"master", "agent"} {
+		r, err = NewRunner(role)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if r.role != role {
+			t.Fatalf("Expected runner role %s. Got %s", role, r.role)
+		}
 	}
 
-	r = NewRunner("agent")
-	if r.role != "agent" {
-		t.Fatalf("expecting role agent. Got %s", r.role)
-	}
-
-	r = NewRunner("agent_public")
-	if r.role != "agent" {
-		t.Fatalf("expecting role agent. Got %s", r.role)
+	// NewRunner() should return an error with these roles.
+	for _, role := range []string{"", "foo", "agent_public"} {
+		r, err = NewRunner(role)
+		if err == nil {
+			t.Fatalf("NewRunner(\"%s\") should return an error but does not", role)
+		}
 	}
 }
 
 func TestRun(t *testing.T) {
-	r := NewRunner("master")
+	r, err := NewRunner("master")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cfg := `
 {
   "cluster_checks": {
@@ -76,7 +91,7 @@ func TestRun(t *testing.T) {
 		expectedOutput = "STDOUT\nSTDERR\n"
 	}
 
-	err := r.Load(strings.NewReader(cfg))
+	err = r.Load(strings.NewReader(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +141,11 @@ func validateCheck(cr *CombinedResponse, name, output string) error {
 }
 
 func TestList(t *testing.T) {
-	r := NewRunner("master")
+	r, err := NewRunner("master")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cfg := `
 {
   "cluster_checks": {
@@ -217,7 +236,11 @@ func validateCheckListing(cr *CombinedResponse, name, description, timeout strin
 }
 
 func TestTimeout(t *testing.T) {
-	r := NewRunner("master")
+	r, err := NewRunner("master")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cfg := `
 {
   "node_checks": {
@@ -238,7 +261,7 @@ func TestTimeout(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("TestTimeout was skipped on Windows")
 	}
-	err := r.Load(strings.NewReader(cfg))
+	err = r.Load(strings.NewReader(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +322,11 @@ func runWithTimeout(d time.Duration, f func()) error {
 
 // TestRunnerParallelism verifies that the check runner runs checks in parallel, using timeouts.
 func TestRunnerParallelism(t *testing.T) {
-	r := NewRunner("master")
+	r, err := NewRunner("master")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cfg := `
 {
   "cluster_checks": {
@@ -351,7 +378,7 @@ func TestRunnerParallelism(t *testing.T) {
     "poststart": ["check1", "check2", "check3", "check4", "check5"]
   }
 }`
-	err := r.Load(strings.NewReader(cfg))
+	err = r.Load(strings.NewReader(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -282,7 +282,7 @@ func TestTimeout(t *testing.T) {
 	}
 }
 
-// runWithTeimout calls f() and returns an error if it takes longer than d to return.
+// runWithTimeout calls f() and returns an error if it takes longer than d to return.
 func runWithTimeout(d time.Duration, f func()) error {
 	finished := make(chan bool, 1)
 	go func() {


### PR DESCRIPTION
This causes `runner.NewRunner()` to return an error if its `role` argument is not either `"master"` or `"agent"`, and fixes the default location of the check runner's config file to be `/opt/mesosphere/etc/dcos-check-runner.yaml`. Also I fixed a typo in a comment while I was here.

https://jira.mesosphere.com/browse/DCOS-38309

DC/OS PR: https://github.com/dcos/dcos/pull/2990