### PR TITLE
Missing checks now are not silently dropped

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -18,6 +18,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/CheckListingResponse"
+        "404":
+          $ref: "#/components/responses/CheckMissingError"
 
     post:
       summary: "Runs node checks and returns their statuses"
@@ -26,6 +28,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/CheckStatusResponse"
+        "404":
+          $ref: "#/components/responses/CheckMissingError"
 
   /cluster/:
 
@@ -36,6 +40,8 @@ paths:
       responses:
         "200":
            $ref: "#/components/responses/CheckListingResponse"
+        "404":
+          $ref: "#/components/responses/CheckMissingError"
 
     post:
       summary: "Runs cluster checks and returns their statuses"
@@ -44,6 +50,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/CheckStatusResponse"
+        "404":
+          $ref: "#/components/responses/CheckMissingError"
 
 components:
 
@@ -124,6 +132,13 @@ components:
             additionalProperties:
               $ref: "#/components/schemas/CheckStatus"
 
+    CheckMissingError:
+      description: "Error indicating that one or more requested checks were not found"
+      content:
+        text/plain:
+          schema:
+            type: string
+            example: "missing checks: [foo]"
   parameters:
 
     CheckQueryParam:

--- a/api/router_test.go
+++ b/api/router_test.go
@@ -515,6 +515,18 @@ func TestAPIErrors(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("nonexistant check", func(t *testing.T) {
+		if sc := getResponse(t, "GET", s.URL+"/node?check=foo", nil, nil).StatusCode; sc != http.StatusNotFound {
+			t.Fatalf("Expected status %d, got %d", http.StatusNotFound, sc)
+		}
+	})
+
+	t.Run("existing and nonexistant check", func(t *testing.T) {
+		if sc := getResponse(t, "GET", s.URL+"/node?check=node-check-master&check=foo", nil, nil).StatusCode; sc != http.StatusNotFound {
+			t.Fatalf("Expected status %d, got %d", http.StatusNotFound, sc)
+		}
+	})
 }
 
 // interfaceSlice returns a []interface{} initialized from strings.


### PR DESCRIPTION
This fixes an issue where specifically requesting checks that don't
exist result in them being silently dropped from the returned struct.
Code paths already existed to handle this cause but weren't being hit
because the code was filtering out missing checks before hitting that,
this change replaces that filtering and allows missing checks to reach
the code that explicitly handles them.

This does differ from the proposed solution in the ticket in that it does not cause the HTTP API to return a 404.
```
❯ http --follow 'localhost:8000/node?check=foo&check=bar'
HTTP/1.1 200 OK
Content-Length: 107
Content-Type: application/json; charset=utf-8
Date: Tue, 26 Feb 2019 10:03:31 GMT

{
    "checks": [
        "foo: Check not found"
    ],
    "error": "One or more requested checks could not be found on this node."
}
```