### PR TITLE
Dcos 50762/standardize jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,14 @@
+pipeline {
+    agent {
+        node {
+            label 'mesos'
+        }
+    }
+    stages {
+        stage('testing') {
+            steps {
+                sh 'make test'
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         }
     }
     stages {
-        stage('testing') {
+        stage('test') {
             steps {
                 sh 'make test'
             }

--- a/owners.json
+++ b/owners.json
@@ -2,6 +2,6 @@
   "amitaekbote" : null,
   "branden" : null,
   "darkonie" : null,
-  "orsenthil": null
+  "orsenthil": null,
   "drewvanstone": null
 }

--- a/owners.json
+++ b/owners.json
@@ -3,4 +3,5 @@
   "branden" : null,
   "darkonie" : null,
   "orsenthil": null
+  "drewvanstone": null
 }


### PR DESCRIPTION
New unified Jenkins build. No more `-master` and `-pulls` builds. 

- [New Build](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fdcos-check-runner-new/activity)
- [Wiki page on Jenkins builds](https://wiki.mesosphere.com/display/ENG/Continuous+Delivery+and+Deployment+with+Jenkins)